### PR TITLE
Add other mime types

### DIFF
--- a/mime-types.json
+++ b/mime-types.json
@@ -1,10 +1,15 @@
 {
+  "audio/3gpp": ["3gp"],
+  "audio/3gpp2": ["3g2"],
+  "audio/aac": ["aac"],
   "audio/midi": ["mid", "midi", "kar", "rmi"],
   "audio/mp4": ["mp4a", "m4a"],
   "audio/mpeg": ["mpga", "mp2", "mp2a", "mp3", "m2a", "m3a"],
   "audio/ogg": ["oga", "ogg", "spx"],
+  "audio/opus": ["opus"],
   "audio/webm": ["weba"],
   "audio/x-matroska": ["mka"],
+  "audio/x-midi": ["mid", "midi"],
   "audio/x-mpegurl": ["m3u"],
   "audio/wav": ["wav"],
   "video/3gpp": ["3gp"],
@@ -18,5 +23,6 @@
   "video/x-fli": ["fli"],
   "video/x-flv": ["flv"],
   "video/x-m4v": ["m4v"],
-  "video/x-matroska": ["mkv", "mk3d", "mks"]
+  "video/x-matroska": ["mkv", "mk3d", "mks"],
+  "video/x-msvideo": ["avi"]
 }


### PR DESCRIPTION
There are a couple of mime types that are missing in this package, here's the list.

`"audio/3gpp": ["3gp"]` - If 3gpp doesn't have a video but has audio will play the audio
` "audio/3gpp2": ["3g2"]` - If 3gpp2 doesn't have a video but has audio will play the audio, supported browsers 
`"audio/aac": ["aac"]` - Another high-quality audio format, more info [here](https://en.wikipedia.org/wiki/Advanced_Audio_Coding)
`"audio/opus": ["opus"]` - Supported [browsers](https://caniuse.com/opus)
`"audio/x-midi": ["mid", "midi"]` - Not supported by Firefox and Safari, [info](https://caniuse.com/?search=mid)
`"video/x-msvideo": ["avi"]` - Mostly a fallback, Edge doesn't support avi videos, safari has partial support, [info](https://caniuse.com/?search=avi)